### PR TITLE
Use os.path.realpath(__file__) instead of sys.argv[0] so script can be run with different python command

### DIFF
--- a/dymoprint
+++ b/dymoprint
@@ -472,8 +472,8 @@ def main(args):
         die(access_error(dev))
 
     # read config file
-    conf_path = os.path.dirname(sys.argv[0])
-    read_config(conf_path+'/'+CONFIG_FILE)
+    conf_path = os.path.dirname(os.path.realpath(__file__))
+    read_config(os.path.join(conf_path, CONFIG_FILE))
 
     labeltext = args.text
     # select font style and offset from parameter

--- a/dymoprint
+++ b/dymoprint
@@ -505,7 +505,7 @@ def main(args):
         # create an empty label image
         labelheight = lm._MAX_BYTES_PER_LINE * 8
         labelwidth = labelheight
-        qr_scale = labelheight / len(qr_text)
+        qr_scale = labelheight // len(qr_text)
         qr_offset = (labelheight - len(qr_text)*qr_scale) / 2
         labelbitmap = Image.new('1', (labelwidth, labelheight))
         labeldraw = ImageDraw.Draw(labelbitmap)


### PR DESCRIPTION
If you want to run the 'dymoprint' script with a different python command than specified in the shebang (e.g. because #!/usr/bin/env python points to python2 but you want to use python3), sys.argv[0] is empty. Therefore the config file is expected to be at /dymoprint.ini:

    # Config file "/dymoprint.ini" not found: writing new config file.

which results in a 'permission denied' error.
This patch attempts to fix that behaviour.