### PR TITLE
Fix deprecation introduced in Pillow 9.2.0

### DIFF
--- a/src/dymoprint/dymo_print_engines.py
+++ b/src/dymoprint/dymo_print_engines.py
@@ -265,9 +265,9 @@ class DymoRenderEngine:
             frame_width = min(frame_width, 3)
 
         font = ImageFont.truetype(font_file_name, fontsize)
-        label_width = max(font.getsize(line)[0] for line in labeltext) + (
-            font_offset * 2
-        )
+        boxes = (font.getbbox(line) for line in labeltext)
+        line_widths = (right - left for left, _, right, _ in boxes)
+        label_width = max(line_widths) + (font_offset * 2)
         text_bitmap = Image.new("1", (label_width, label_height))
         with draw_image(text_bitmap) as label_draw:
             # draw frame into empty image


### PR DESCRIPTION
Pillow 8.0.0 [introduced](https://pillow.readthedocs.io/en/stable/releasenotes/8.0.0.html#imagedraw-textbbox) a `getbbox` method, which is meant to replace `getsize`.

Since Pillow 9.2.0, `getsize` has been [deprecated](https://pillow.readthedocs.io/en/stable/releasenotes/9.2.0.html#font-size-and-offset-methods) and subsequently [removed](https://pillow.readthedocs.io/en/stable/releasenotes/10.0.0.html#font-size-and-offset-methods) in Pillow 10.0.0.

This PR transitions the `getsize` usage to `getbbox` in order to fix the deprecation and to unblock a future dependency version upgrade to Pillow 10.
