### PR TITLE
Fix typos in min_payload_len

### DIFF
--- a/src/dymoprint/command_line.py
+++ b/src/dymoprint/command_line.py
@@ -226,7 +226,10 @@ def main():
     )
 
     label_bitmap = render_engine.merge_render(
-        bitmaps, min_payload_len_px, max_payload_len_px, justify
+        bitmaps=bitmaps,
+        min_payload_len_px=min_payload_len_px,
+        max_payload_len_px=max_payload_len_px,
+        justify=justify,
     )
 
     # print or show the label

--- a/src/dymoprint/dymo_print_engines.py
+++ b/src/dymoprint/dymo_print_engines.py
@@ -327,7 +327,12 @@ class DymoRenderEngine:
         return Image.new("1", (1, label_height))
 
     def merge_render(
-        self, bitmaps, min_payload_len=0, max_payload_len=None, justify="center"
+        self,
+        *,
+        bitmaps,
+        min_payload_len_px=0,
+        max_payload_len_px=None,
+        justify="center",
     ):
         """
         Merges multiple images into a single image.
@@ -352,12 +357,12 @@ class DymoRenderEngine:
                 label_bitmap.paste(bitmap, box=(offset, 0))
                 offset += bitmap.width + padding
         elif len(bitmaps) == 0:
-            label_bitmap = self.render_empty(max(min_payload_len, 1))
+            label_bitmap = self.render_empty(max(min_payload_len_px, 1))
         else:
             label_bitmap = bitmaps[0]
 
-        if max_payload_len is not None and label_bitmap.width > max_payload_len:
-            excess_px = label_bitmap.width - max_payload_len
+        if max_payload_len_px is not None and label_bitmap.width > max_payload_len_px:
+            excess_px = label_bitmap.width - max_payload_len_px
             excess_mm = excess_px / PIXELS_PER_MM
             # Round up to nearest 0.1mm
             excess_mm = math.ceil(excess_mm * 10) / 10
@@ -366,16 +371,16 @@ class DymoRenderEngine:
                 f"exceeds allowed length of {excess_mm:.1f} mm."
             )
 
-        if min_payload_len > label_bitmap.width:
+        if min_payload_len_px > label_bitmap.width:
             offset = 0
             if justify == "center":
-                offset = max(0, int((min_payload_len - label_bitmap.width) / 2))
+                offset = max(0, int((min_payload_len_px - label_bitmap.width) / 2))
             if justify == "right":
-                offset = max(0, int(min_payload_len - label_bitmap.width))
+                offset = max(0, int(min_payload_len_px - label_bitmap.width))
             out_label_bitmap = Image.new(
                 "1",
                 (
-                    min_payload_len,
+                    min_payload_len_px,
                     label_bitmap.height,
                 ),
             )

--- a/src/dymoprint/gui.py
+++ b/src/dymoprint/gui.py
@@ -131,8 +131,8 @@ class DymoPrintWindow(QWidget):
         self.render_engine = DymoRenderEngine(self.tape_size.currentData())
         justify = self.justify.currentText()
         min_label_mm_len: int = self.min_label_len.value()
-        min_payload_len = max(0, (min_label_mm_len * 7) - self.margin.value() * 2)
-        self.list.update_params(self.render_engine, min_payload_len, justify)
+        min_payload_len_px = max(0, (min_label_mm_len * 7) - self.margin.value() * 2)
+        self.list.update_params(self.render_engine, min_payload_len_px, justify)
 
     def update_label_render(self, label_bitmap):
         self.label_bitmap = label_bitmap

--- a/src/dymoprint/q_dymo_labels_list.py
+++ b/src/dymoprint/q_dymo_labels_list.py
@@ -34,9 +34,11 @@ class QDymoLabelList(QListWidget):
 
     renderSignal = QtCore.pyqtSignal(Image.Image, name="renderSignal")
 
-    def __init__(self, render_engine, min_payload_len=0, justify="center", parent=None):
+    def __init__(
+        self, render_engine, min_payload_len_px=0, justify="center", parent=None
+    ):
         super().__init__(parent)
-        self.min_payload_len = min_payload_len
+        self.min_payload_len_px = min_payload_len_px
         self.justify = justify
         self.render_engine = render_engine
         self.setAlternatingRowColors(True)
@@ -58,15 +60,15 @@ class QDymoLabelList(QListWidget):
         super().dropEvent(e)
         self.render_label()
 
-    def update_params(self, render_engine, min_payload_len=0, justify="center"):
+    def update_params(self, render_engine, min_payload_len_px=0, justify="center"):
         """
         Updates the render engine used for rendering the label.
         Args:
             justify: justification [center,left,right]
-            min_payload_len: minimum payload size
+            min_payload_len_px: minimum payload size
             render_engine (RenderEngine): The new render engine to use.
         """
-        self.min_payload_len = min_payload_len
+        self.min_payload_len_px = min_payload_len_px
         self.justify = justify
         self.render_engine = render_engine
         for i in range(self.count()):
@@ -86,7 +88,10 @@ class QDymoLabelList(QListWidget):
                 item.setSizeHint(item_widget.sizeHint())
                 bitmaps.append(item_widget.render_label())
         label_bitmap = self.render_engine.merge_render(
-            bitmaps, self.min_payload_len, self.justify
+            bitmaps=bitmaps,
+            min_payload_len_px=self.min_payload_len_px,
+            max_payload_len_px=None,
+            justify=self.justify,
         )
 
         self.renderSignal.emit(label_bitmap)


### PR DESCRIPTION
This was leading to

```python
TypeError: '>' not supported between instances of 'int' and 'str'
```