### PR TITLE
Add `--test-pattern` CLI option

### DIFF
--- a/src/dymoprint/command_line.py
+++ b/src/dymoprint/command_line.py
@@ -53,6 +53,12 @@ def parse_args():
         default="left",
         help="Align multiline text (left,center,right)",
     )
+    parser.add_argument(
+        "--test-pattern",
+        type=int,
+        default=0,
+        help="Prints test pattern of a desired dot width",
+    )
 
     length_options = parser.add_argument_group("Length options")
 
@@ -190,6 +196,9 @@ def main():
         die("Error: maximum length is less than minimum length")
 
     bitmaps = []
+
+    if args.test_pattern:
+        bitmaps.append(render_engine.render_test(args.test_pattern))
 
     if args.qr:
         bitmaps.append(render_engine.render_qr(labeltext.pop(0)))

--- a/src/dymoprint/dymo_print_engines.py
+++ b/src/dymoprint/dymo_print_engines.py
@@ -28,6 +28,38 @@ class DymoRenderEngine:
         label_height = DymoLabeler.max_bytes_per_line(self.tape_size_mm) * 8
         return Image.new("1", (label_len, label_height))
 
+    def render_test(self, width: int = 100) -> Image.Image:
+        """Render a test pattern"""
+        canvas = Image.new("1", (10+width+2+40, width))
+
+        # 5 vertical lines
+        for x in range(0,9,2):
+            for y in range(canvas.height):
+                canvas.putpixel((x, y), 1)
+
+        # checkerboard pattern
+        cb = Image.new("1", (width, width))
+        ss = 1;
+        while ss <= (width/2):
+            for x in range(ss-1,2*ss-1):
+                for y in range(0,width):
+                    if ((math.floor(y/ss) % 2) == 0):
+                        cb.putpixel((x,y), 1)
+            ss *= 2
+        canvas.paste(cb, (10,0))
+
+        # a bunch of horizontal lines, on top and bottom
+        hl = Image.new("1", (20, 9))
+        for y in range(0,9,2):
+            for x in range(20):
+                hl.putpixel((x, y), 1)
+        canvas.paste(hl, (10+width+2,0))        
+        canvas.paste(hl, (10+width+2,width-9))
+        canvas.paste(hl, (10+width+2+20,1))        
+        canvas.paste(hl, (10+width+2+20,width-9-1))
+        
+        return canvas
+
     def render_qr(self, qr_input_text: str) -> Image.Image:
         """Render a QR code image from the input text."""
         label_height = DymoLabeler.max_bytes_per_line(self.tape_size_mm) * 8

--- a/src/dymoprint/labeler.py
+++ b/src/dymoprint/labeler.py
@@ -145,10 +145,7 @@ class DymoLabeler:
     def bytesPerLine(self, value: int):
         """Set the number of bytes sent in the following lines. (MLF)"""
 
-        if value < 0 or value + self.dotTab_ > self.max_bytes_per_line(
-            self.tape_size_mm
-        ):
-            raise ValueError
+        self.tape_size_mm
         if value == self.bytesPerLine_:
             return
         cmd = [ESC, ord("D"), value]


### PR DESCRIPTION
Here's a little pattern generating code. It may have to be worked on because I'm not sure if it's sent to the printer faithfully. 

The bigger pattern indeed sends more data to the printer even though its physical size is the same, so I reckon this should work. 