### PR TITLE
Remove pyqt6-tools dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,6 @@ dependencies = [
     "python-barcode>=0.13.1,<1",
     "pyusb",
     "PyQt6",
-    "PyQt6-tools",
 ]
 classifiers = [
     "Operating System :: POSIX :: Linux",


### PR DESCRIPTION
As far as I can tell, this is an optional development dependency, and it was giving me trouble during installation.