### PR TITLE
Drop support for Python 3.7

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9, 3.10, 3.11, 3.12]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
       fail-fast: false
 
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
       fail-fast: false
 
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,6 +11,7 @@ jobs:
     strategy:
       matrix:
         python-version: [3.7, 3.12]
+      fail-fast: false
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.12]
+        python-version: [3.7, 3.8, 3.9, 3.10, 3.11, 3.12]
       fail-fast: false
 
     steps:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v4.4.0
+  rev: v4.5.0
   hooks:
   - id: no-commit-to-branch
     args: [--branch, master, --branch, main]
@@ -18,7 +18,7 @@ repos:
     args: ['--fix=lf']
 
 - repo: https://github.com/asottile/pyupgrade
-  rev: v3.4.0
+  rev: v3.15.0
   hooks:
   - id: pyupgrade
     args: ["--py38-plus", "--keep-runtime-typing"]
@@ -30,13 +30,13 @@ repos:
     args: ["--settings-path=pyproject.toml"]
 
 - repo: https://github.com/psf/black
-  rev: 23.3.0
+  rev: 23.11.0
   hooks:
   - id: black
     language_version: python3
 
 - repo: https://github.com/pycqa/flake8
-  rev: 6.0.0
+  rev: 6.1.0
   hooks:
   - id: flake8
     args:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,7 +21,7 @@ repos:
   rev: v3.4.0
   hooks:
   - id: pyupgrade
-    args: ["--py37-plus", "--keep-runtime-typing"]
+    args: ["--py38-plus", "--keep-runtime-typing"]
 
 - repo: https://github.com/pycqa/isort
   rev: 5.12.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,11 +66,19 @@ legacy_tox_ini = """
 [tox]
 envlist =
   py37
+  py38
+  py39
+  py310
+  py311
   py312
 
 [gh-actions]
 python =
     3.7: py37
+    3.8: py38
+    3.9: py39
+    3.10: py310
+    3.11: py311
     3.12: py312
 
 [testenv]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,6 @@ dependencies = [
 classifiers = [
     "Operating System :: POSIX :: Linux",
     "License :: OSI Approved :: Apache Software License",
-    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
@@ -35,7 +34,7 @@ classifiers = [
     "Topic :: Printing"
 ]
 dynamic = ["version"]
-requires-python = ">=3.7,<4"
+requires-python = ">=3.8,<4"
 
 [project.urls]
 Homepage = "https://github.com/computerlyrik/dymoprint"
@@ -65,7 +64,6 @@ profile = "black"
 legacy_tox_ini = """
 [tox]
 envlist =
-  py37
   py38
   py39
   py310
@@ -74,7 +72,6 @@ envlist =
 
 [gh-actions]
 python =
-    3.7: py37
     3.8: py38
     3.9: py39
     3.10: py310


### PR DESCRIPTION
The test suite is failing, it seems like there's trouble with the PyQt6 installation. It's not worth my time to track down the problem, especially since 3.7 is ancient by now, so support is, as of right now, dropped.